### PR TITLE
Change post-install to run migrations

### DIFF
--- a/edgebox-postinstall.txt
+++ b/edgebox-postinstall.txt
@@ -1,3 +1,4 @@
 -T -w /var/www/html api-ws composer install
--T api-ws ./bin/console doctrine:schema:create
+-T api-ws ./bin/console doctrine:database:create -n
+-T api-ws ./bin/console doctrine:migrations:migrate -n
 -T api-ws chmod -R 777 /var/www/html/var


### PR DESCRIPTION
Change post-install to:

- Create Schema
- Run Migrations

Subsequent executions yield:


```
Executing script cache:clear [OK]
Executing script assets:install public [OK]

 -> docker-compose exec -T api-ws ./bin/console doctrine:database:create -n
Created database /var/www/html/var/data.db for connection named default
 -> docker-compose exec -T api-ws ./bin/console doctrine:migrations:migrate -n

 [OK] Already at the latest version ("DoctrineMigrations\Version20210519104604")

 -> docker-compose exec -T api-ws chmod -R 777 /var/www/html/var
 -> docker-compose exec -T nextcloud-ws chown www-data config
 -> docker-compose exec -T nextcloud-ws chown www-data data
 -> docker-compose exec -T -u 33 nextcloud-ws php occ maintenance:install --database=mysql --database-name=docker --database-host=nextcloud-db --database-user=docker --database-pass=docker --admin-user=system --admin-pass=pw
 -> docker-compose exec -T -u 33 nextcloud-ws php occ config:system:set trusted_domains 1 --value=nextcloud.edgebox.local
 -> docker-compose exec -T -u 33 nextcloud-ws php occ config:system:set trusted_domains 2 --value=
 -> docker-compose exec -T -u 33 nextcloud-ws php occ config:system:set overwrite.cli.url --value=http://nextcloud.edgebox.local
Finished post-install operations
Publishing mDNS service entries for modules to 192.168.1.54
Found configuration for api service
Publishing mDNS service entries for edgeapps to 192.168.1.54
Found configuration for n8n edgeapp
Found configuration for nextcloud edgeapp
```