### PR TITLE
Simplified calculations for uptime days, hours, and minutes

### DIFF
--- a/src/src/Controller/HomeController.php
+++ b/src/src/Controller/HomeController.php
@@ -69,18 +69,18 @@ class HomeController extends AbstractController
         $uptime = $this->systemHelper->getUptimeInSeconds();
 
         $days = $uptime / (60 * 60 * 24);
-        $hours = ($uptime - ($days * 60 * 60 * 24)) / (60 * 60);
-        $minutes = (($uptime - ($days * 60 * 60 * 24)) - ($hours * 60 * 60)) / 60;
+        $hours = $uptime / (60 * 60);
+        $minutes = $uptime / 60;
 
-        if ($days > 0) {
+        if ($days >= 2) {
             return (int) $days.' days';
         }
 
-        if ($hours > 0) {
+        if ($hours >= 2) {
             return (int) $hours.' hours';
         }
 
-        if ($minutes > 0) {
+        if ($minutes >= 2) {
             return (int) $minutes.' minutes';
         }
 


### PR DESCRIPTION
Calculation was not correct, was returning weird values for minutes and hours, and displaying 0 days as uptime.

Code is simplified and works properly now:
![image](https://user-images.githubusercontent.com/1270431/122040420-0f677300-cdd8-11eb-8fcf-00759c88282b.png)
