### PR TITLE
Apps quickaccess widget on main page

### DIFF
--- a/src/src/Controller/HomeController.php
+++ b/src/src/Controller/HomeController.php
@@ -283,11 +283,11 @@ class HomeController extends AbstractController
 
         if (!empty($apps_list)) {
             foreach ($apps_list as $edgeapp) {
-                if ('on' == $edgeapp['status']['description'] && $edgeapp['internet_accessible']) {
+                if ('on' == $edgeapp['status']['description']) {
                     ++$result['total'];
                     $result['apps'][] = [
                         'id' => $edgeapp['id'],
-                        'url' => $edgeapp['internet_url']
+                        'url' => $edgeapp['internet_accessible'] ? $edgeapp['internet_url'] : 'http://' . $edgeapp['network_url']
                     ];
                 }
             }

--- a/src/src/Controller/HomeController.php
+++ b/src/src/Controller/HomeController.php
@@ -48,6 +48,7 @@ class HomeController extends AbstractController
             'container_working_edgeapps' => $this->getWorkingEdgeAppsContainerVars(),
             'container_storage_summary' => $this->getStorageSummaryContainerVars(),
             'container_actions_overview' => $this->getActionsOverviewContainerVars(),
+            'container_apps_quickaccess' => $this->getQuickEdgeAppsAccessContainerVars(),
         ]);
     }
 
@@ -251,4 +252,29 @@ class HomeController extends AbstractController
 
         return $result;
     }
+
+    private function getQuickEdgeAppsAccessContainerVars(): array
+    {
+        $apps_list = $this->edgeAppsHelper->getEdgeAppsList();
+
+        $result = [
+            'total' => 0,
+            'apps' => []
+        ];
+
+        if (!empty($apps_list)) {
+            foreach ($apps_list as $edgeapp) {
+                if ('on' == $edgeapp['status']['description'] && $edgeapp['internet_accessible']) {
+                    ++$result['total'];
+                    $result['apps'][] = [
+                        'id' => $edgeapp['id'],
+                        'url' => $edgeapp['internet_url']
+                    ];
+                }
+            }
+        }
+
+        return $result;
+    }
+
 }

--- a/src/templates/home/index.html.twig
+++ b/src/templates/home/index.html.twig
@@ -4,7 +4,10 @@
     Web Dashboard
 {% endblock title %}
 {% block content %}
-  <div class="row">
+
+  {{ include('partials/_container_quick_edgeapps_access.html.twig', {apps_quickaccess: container_apps_quickaccess.apps})}}
+
+  <div class="row mt-4">
 
     {% if container_system_uptime == '100 days' or container_system_uptime == '365 days' %}
     

--- a/src/templates/partials/_container_quick_edgeapps_access.html.twig
+++ b/src/templates/partials/_container_quick_edgeapps_access.html.twig
@@ -16,11 +16,11 @@
                     {# <div class="card">
                         <div class="card-body p-3"> #}
                             {# <div class="row"> #}
-                                <a href="https://{{app.url}}" target="_blank">
+                                <a href="{{app.url}}" target="_blank">
                                     <div class="col-12 col-lg-12 ms-auto text-center mt-0 mt-lg-0">
-                                        <div class="bg-gradient-primary border-radius-lg h-100">
+                                        <div class="bg-gradient-{{dashboard_settings.color_mood}} border-radius-lg h-100">
                                             <div class="position-relative d-flex align-items-center justify-content-center h-100">
-                                            <img class="w-100 position-relative z-index-2" src="/assets/img/edgeapps/{{app.id}}.png">
+                                                <img class="w-100 position-relative z-index-2" src="/assets/img/edgeapps/{{app.id}}.png">
                                             </div>
                                         </div>
                                     </div>

--- a/src/templates/partials/_container_quick_edgeapps_access.html.twig
+++ b/src/templates/partials/_container_quick_edgeapps_access.html.twig
@@ -1,0 +1,37 @@
+<div class="card">
+    <div class="card-header pb-0">
+        <h6>Quick Access</h6>
+    </div>
+    <div class="card-body p-3">
+        {% if not apps_quickaccess %}
+        <div class="py-3 text-center actions-overview-empty">
+            <i class="ni ni-bullet-list-67 ni-3x"></i>
+            <h4 class="mt-4">No apps running</h4>
+            <p>Once you get some apps running, they will appear here for quick access</p>
+        </div>
+        {% else %}
+        <div class="row">
+            {% for app in apps_quickaccess %}
+                <div class="edgeapp {{app.id}} col-3 col-sm-2 col-lg-1 mb-lg-0 mb-2 mt-0" id="{{app.id}}">
+                    {# <div class="card">
+                        <div class="card-body p-3"> #}
+                            {# <div class="row"> #}
+                                <a href="https://{{app.url}}" target="_blank">
+                                    <div class="col-12 col-lg-12 ms-auto text-center mt-0 mt-lg-0">
+                                        <div class="bg-gradient-primary border-radius-lg h-100">
+                                            <div class="position-relative d-flex align-items-center justify-content-center h-100">
+                                            <img class="w-100 position-relative z-index-2" src="/assets/img/edgeapps/{{app.id}}.png">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            {# </div> #}
+                        {# </div>
+                    </div> #}
+                </div>
+
+            {% endfor %}
+        </div>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
This PR adds quick app access icons to the dashboard homepage. Only currently running apps are displayed.

Mobile:
![Screenshot 2022-10-08 at 18 16 37](https://user-images.githubusercontent.com/1270431/194717206-f41167e6-5e10-419c-a380-b868ac3c05a5.png)

Desktop:
![image](https://user-images.githubusercontent.com/1270431/194717243-8199142b-8b04-4046-8160-7273511dbd5f.png)
