### PR TITLE
Replacing bullseye with buster for php base image

### DIFF
--- a/bin/api-ws/Dockerfile
+++ b/bin/api-ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache-bullseye
+FROM php:8.1-apache-buster
 
 # Surpresses debconf complaints of trying to install apt packages interactively
 # https://github.com/moby/moby/issues/4032#issuecomment-192327844


### PR DESCRIPTION
The FROM `php:8.1-apache-bullseye` base image does not behave well with the `armhf` arch
When building from scratch on an installation powered by `ua-netinst-config` (on a raspberry pi 4), we errors on image build while running the first command `apt-get install -y update` related to invalid signatures for debian repos.

Changing the debian distribution behind this image to "buster" solves the issue. Keeps the 8.1 php upgrade ;) 