### PR TITLE
Fix php-cs-fixer single_quote violation in SecurityController

### DIFF
--- a/src/src/Controller/SecurityController.php
+++ b/src/src/Controller/SecurityController.php
@@ -21,7 +21,7 @@ class SecurityController extends AbstractController
     #[Route('/login', name: 'app_login')]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
-        if ($this->isGranted("IS_AUTHENTICATED_FULLY")) {
+        if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             return $this->redirectToRoute('home');
         }
 


### PR DESCRIPTION
## Summary

Fixes the failing `php-cs-fixer` job on the release/1.4.0 PR (#82).

The `single_quote` rule in `.php-cs-fixer.dist.php` flagged `src/Controller/SecurityController.php` because the argument to `$this->isGranted(...)` was wrapped in double quotes. PHP CS Fixer requires single quotes for string literals where there is no interpolation.

## Change

```diff
- if ($this->isGranted("IS_AUTHENTICATED_FULLY")) {
+ if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
```

## Test plan

- [x] Verified the file now contains single quotes via `grep "isGranted" src/Controller/SecurityController.php`.
- [ ] Re-run the `php-cs-fixer` GitHub Action and confirm it passes.